### PR TITLE
✨: Add force option to runApp function

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -7,7 +7,11 @@ import { stringLengthToBytes } from "./util";
 import { addMissingFiles } from "./steps/add-missing";
 import { commitFiles } from "./steps/commit-files";
 
-export async function runApp() {
+export interface RunAppOptions {
+  force?: boolean;
+}
+
+export async function runApp({ force = false }: RunAppOptions = {}) {
   // console.log(process.env["PWD"]);
   intro("Comitting your changes");
   const status = await getStatus();
@@ -38,15 +42,18 @@ export async function runApp() {
   s.stop("Generated commits");
 
   renderCommits(commits);
-  const shouldCommit = await confirm({
-    message: "Do you want to commit?",
-  });
-  if (isCancel(shouldCommit)) {
-    outro("Cancelled");
-    return;
-  } else if (!shouldCommit) {
-    outro("not done anything");
-    return;
+
+  if (!force) {
+    const shouldCommit = await confirm({
+      message: "Do you want to commit?",
+    });
+    if (isCancel(shouldCommit)) {
+      outro("Cancelled");
+      return;
+    } else if (!shouldCommit) {
+      outro("not done anything");
+      return;
+    }
   }
 
   await commitFiles(commits, status);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2,8 +2,15 @@ import { parseArgs } from "util";
 import { runApp } from "./app";
 
 export async function run() {
-  // console.log(values);
-  // console.log(positionals);
+  const { values } = parseArgs({
+    options: {
+      force: {
+        type: "boolean",
+        short: "f",
+        default: false,
+      },
+    },
+  });
 
-  await runApp();
+  await runApp({ force: values.force });
 }


### PR DESCRIPTION
Introduced a new `force` option to the `runApp` function, allowing users to bypass the commit confirmation prompt. Updated the CLI to support this new option with a `-f` flag.
